### PR TITLE
Fix CI workflow: syntax, runner, and replace hanging TUI launch with …

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,14 +3,17 @@ name: Sanity test
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-  build:
+  sanity:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6
-    - name: SetUp Python3
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: '3.x'
@@ -18,6 +21,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Sanity check
+    - name: Import check
       run: |
-        python src/main.py
+        cd src
+        python -c "
+        from zd_version import ZDVersion
+        from deployment_manager import ZDManager, ZDStep
+        from audit_logger import ZDLogger
+        from deployment_executor import ZDExecutor
+        from zd_base import BaseScreen
+        from splash_screen import ZDSplashScreen
+
+        version, _ = ZDVersion.get_version()
+        manager = ZDManager()
+        assert manager.validate_zd(), 'Manager validation failed'
+        print(f'All imports OK, version: {version}')
+        "


### PR DESCRIPTION
…import check

  - Add missing colon in branches trigger syntax
  - Change runs-on from debian-12 to ubuntu-latest
  - Replace python src/main.py (hangs - TUI needs terminal) with module import and validation check
  - Add pull_request and workflow_dispatch triggers
  - Remove unnecessary typing from requirements.txt
  - Fix requirements.txt typo in README